### PR TITLE
Fix networking between VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,6 +31,7 @@ Vagrant.configure("2") do |config|
       ansible.groups = {
         "controller" => ["ctrl"]
       }
+      ansible.extra_vars = { worker_count: NUM_WORKERS }
     end
   end
 
@@ -54,6 +55,7 @@ Vagrant.configure("2") do |config|
             "controller" => ["ctrl"],
             "workers" => (1..NUM_WORKERS).map { |k| "node-#{k}" }
           }
+          ansible.extra_vars = { worker_count: NUM_WORKERS }
         end
       end
     end

--- a/ansible/general.yaml
+++ b/ansible/general.yaml
@@ -60,8 +60,9 @@
 
     # Step 8: Hosts
     - name: Manage /etc/hosts
-      ansible.builtin.copy:
-        src: templates/hosts.j2
+      become: true
+      ansible.builtin.template:
+        src: hosts.j2
         dest: /etc/hosts
         owner: root
         group: root

--- a/ansible/templates/hosts.j2
+++ b/ansible/templates/hosts.j2
@@ -1,11 +1,6 @@
-127.0.0.1   localhost
+127.0.0.1 localhost
 
-# Controller
-{% for host in groups['controller'] %}
-{{ hostvars[host]['ansible_host'] }}    {{ host }}
-{%endfor%}
-
-# Workers
-{% for host in groups['workers'] %}
-{{ hostvars[host]['ansible_host'] }}    {{ host }}
-{%endfor%}
+192.168.56.100 ctrl
+{% for i in range(1, (worker_count | int) + 1) %}
+192.168.56.{{ 100 + i }} node-{{ i }}
+{% endfor %}


### PR DESCRIPTION
Pinging between ctrl and worker nodes did not work in the previous version. 

For testing I run the following:

From ctrl:
```
vagrant ssh ctrl
getent hosts node-1
getent hosts node-2
ping -c 2 node-1
ping -c 2 node-2
```

From node 1:
```
vagrant ssh node-1
getent hosts ctrl
ping -c 2 ctrl
```

Running `cat /etc/hosts` now gives: 
```
127.0.0.1 localhost

192.168.56.100 ctrl
192.168.56.101 node-1
192.168.56.102 node-2
```


