### PR TITLE
Increase rate limits for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ minikube tunnel
 
 
 # Test the global limit 
-for i in {1..15}; do
+for i in {1..110}; do
   curl -s -o /dev/null -w "Request $i: %{http_code}\n" http://app.stable.example.com/sms/
 done
 ```
@@ -251,22 +251,22 @@ Expected output:
 Request 1: 200
 Request 2: 200
 ...
-Request 10: 200
-Request 11: 429
-Request 12: 429
+Request 100: 200
+Request 101: 429
+Request 102: 429
 ...
 ```
 
 # Test the user-specific limit 
 ```bash
-for i in {1..6}; do
+for i in {1..15}; do
   curl -s -o /dev/null \
     -H "x-user-id: user1" \
     -w "user1 Request $i: %{http_code}\n" \
     http://app.stable.example.com/sms/
 done
 
-for i in {1..6}; do
+for i in {1..15}; do
   curl -s -o /dev/null \
     -H "x-user-id: user2" \
     -w "user2 Request $i: %{http_code}\n" \
@@ -276,10 +276,10 @@ done
 
 Expected Output:
 
-- First 4 requests (user1) are allowed
-- Last 2 Requests (user1) are rejected
-- First 4 requests (user2) are allowed
-- Last 2 requests (user2) are rejected
+- First 10 requests (user1) are allowed
+- Last 5 Requests (user1) are rejected
+- First 10 requests (user2) are allowed
+- Last 5 requests (user2) are rejected
 
 
 ### If encountering issues

--- a/app-stack/templates/ratelimit-config.yaml
+++ b/app-stack/templates/ratelimit-config.yaml
@@ -13,8 +13,8 @@ data:
         value: "/sms/"
         rate_limit:
           unit: minute
-          requests_per_unit: 10
+          requests_per_unit: {{ .Values.ratelimit.global_limit }}
       - key: USER_ID
         rate_limit:
           unit: minute
-          requests_per_unit: 4
+          requests_per_unit: {{ .Values.ratelimit.user_limit }}

--- a/app-stack/values.yaml
+++ b/app-stack/values.yaml
@@ -112,3 +112,5 @@ versions:
 
 ratelimit:
   domain: ratelimit
+  global_limit: 100
+  user_limit: 10

--- a/test-scripts/test-global-rate-limit.sh
+++ b/test-scripts/test-global-rate-limit.sh
@@ -6,7 +6,7 @@ kubectl wait --for=condition=ready pod rate-limit-test --timeout=30s
 
 # Test: All requests should return same version
 kubectl exec rate-limit-test -- sh -c "
-for i in \$(seq 1 20);
+for i in \$(seq 1 110);
   do curl -s -I http://$INGRESS_IP:80/sms/ -H 'Host: app.stable.example.com' | grep HTTP/1.1;
 done" | awk '{$1=""; print $0}' | sort | uniq -c
 

--- a/test-scripts/test-user-rate-limit.sh
+++ b/test-scripts/test-user-rate-limit.sh
@@ -6,13 +6,13 @@ kubectl wait --for=condition=ready pod rate-limit-test --timeout=30s
 
 echo "For user1"
 kubectl exec rate-limit-test -- sh -c "
-for i in \$(seq 1 10);
+for i in \$(seq 1 15);
   do curl -s -I http://$INGRESS_IP:80/sms/ -H 'Host: app.stable.example.com' -H 'x-user-id: user1' | grep HTTP/1.1;
 done" | awk '{$1=""; print $0}' | sort | uniq -c
 
 echo "For user2"
 kubectl exec rate-limit-test -- sh -c "
-for i in \$(seq 1 10);
+for i in \$(seq 1 15);
   do curl -s -I http://$INGRESS_IP:80/sms/ -H 'Host: app.stable.example.com' -H 'x-user-id: user2' | grep HTTP/1.1;
 done" | awk '{$1=""; print $0}' | sort | uniq -c
 


### PR DESCRIPTION
Increasing the global rate limit to 100 and the user-limit to 10, so we don't have any issues during the demo.